### PR TITLE
Add check for existence of temp_download_dir

### DIFF
--- a/wall.py
+++ b/wall.py
@@ -3,7 +3,10 @@ import os
 import winpath
 
 def temp_download_dir():
-    return winpath.get_local_appdata() + "\\Programs\\KustomPyper"
+    path = winpath.get_local_appdata() + "\\Programs\\KustomPyper"
+    if not os.path.exists(path):
+        os.mkdir(path)
+    return path
 
 
 def changeBG(image):


### PR DESCRIPTION
The open() function, though creates missing files in write mode, doesn't
check for existence of directories for the path specified and result in an
exception.
To overcome this, a check is applied to create the directory if missing.
This fixes #1.