### PR TITLE
Fix crash when search returns zero results

### DIFF
--- a/src/wallhaven.py
+++ b/src/wallhaven.py
@@ -79,6 +79,10 @@ class Wallhaven:
             image_count = 0
             for _ in response.json()["data"]:
                 image_count += 1
+                
+            if image_count == 0:
+                return False
+
             index = random.randint(0, image_count - 1)
             print(image_count)
             print(index)


### PR DESCRIPTION
If you search for something that doesn't return results you get the following error `ValueError: empty range for randrange() (0,0, 0)` which then leads to the app crashing.