### PR TITLE
Fix `top_list` in UI file

### DIFF
--- a/src/kustompyper.u.ui
+++ b/src/kustompyper.u.ui
@@ -513,7 +513,7 @@
           </item>
           <item>
            <property name="text">
-            <string>top_list</string>
+            <string>toplist</string>
            </property>
           </item>
           <item>


### PR DESCRIPTION
This is the same change as the previous or (https://github.com/kriticalflare/KustomPyper/pull/4) but this time fixing the UI file.

For posterity: Wallhaven doesn't have a `top_list` argument, it's `toplist`.